### PR TITLE
readme_note: note for >= 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ Table of contents
 * [License](#license)
 
 ### Prerequisites
-* Unity Editor version 2018.*
+* Unity Editor version 2018.* 
 * Android 4.1 (API level 16)+ (when building for Android)
 * iOS 9.0+ (when building for iOS)
+
+*The app will work on unity versions >= 2021 but requires some adjustments to the build and resource files.
 
 ## Project Setup
 


### PR DESCRIPTION
Readme already specified that the editor required was 2018 but this note adds the extra info about the possibility to work in more modern editors but not without some adjustments first.